### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/qbws.js
+++ b/lib/qbws.js
@@ -3,7 +3,7 @@ var soap = require('soap');
 var chalk = require('chalk');
 var fs = require('fs');
 var builder = require('xmlbuilder');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var qbws,
     server,

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "QuickBooks Web Connector"
   ],
   "dependencies": {
-    "soap": "0.9.1",
     "chalk": "1.1.1",
-    "xmlbuilder": "2.6.4",
-    "node-uuid": "1.4.3"
+    "soap": "0.9.1",
+    "uuid": "^3.0.0",
+    "xmlbuilder": "2.6.4"
   },
   "devDependencies": {
     "jshint": "2.1.x",
@@ -48,38 +48,42 @@
   },
   "jscsConfig": {
     "requireCurlyBraces": [
-        "if",
-        "else",
-        "for",
-        "while",
-        "do",
-        "try",
-        "catch"
+      "if",
+      "else",
+      "for",
+      "while",
+      "do",
+      "try",
+      "catch"
     ],
     "requireSpaceAfterKeywords": [
-        "if",
-        "else",
-        "for",
-        "while",
-        "do",
-        "switch",
-        "case",
-        "return",
-        "try",
-        "catch",
-        "typeof"
+      "if",
+      "else",
+      "for",
+      "while",
+      "do",
+      "switch",
+      "case",
+      "return",
+      "try",
+      "catch",
+      "typeof"
     ],
     "requireSpaceBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,
     "requireSpacesInConditionalExpression": true,
     "disallowSpacesInNamedFunctionExpression": {
-        "beforeOpeningRoundBrace": true
+      "beforeOpeningRoundBrace": true
     },
     "disallowSpacesInFunctionDeclaration": {
-        "beforeOpeningRoundBrace": true
+      "beforeOpeningRoundBrace": true
     },
     "requireSpaceBetweenArguments": true,
-    "requireMultipleVarDecl": { "allExcept": ["require"] },
+    "requireMultipleVarDecl": {
+      "allExcept": [
+        "require"
+      ]
+    },
     "requireVarDeclFirst": true,
     "requireBlocksOnNewline": true,
     "disallowEmptyBlocks": true,
@@ -90,25 +94,25 @@
     "disallowSpaceAfterPrefixUnaryOperators": true,
     "disallowSpaceBeforePostfixUnaryOperators": true,
     "disallowSpaceBeforeBinaryOperators": [
-        ","
+      ","
     ],
     "requireSpacesInForStatement": true,
     "requireSpacesInAnonymousFunctionExpression": {
-        "beforeOpeningRoundBrace": true,
-        "beforeOpeningCurlyBrace": true
+      "beforeOpeningRoundBrace": true,
+      "beforeOpeningCurlyBrace": true
     },
     "requireSpaceBeforeBinaryOperators": true,
     "requireSpaceAfterBinaryOperators": true,
     "disallowKeywords": [
-        "with",
-        "continue"
+      "with",
+      "continue"
     ],
     "validateIndentation": 4,
     "disallowMixedSpacesAndTabs": true,
     "disallowTrailingWhitespace": true,
     "disallowTrailingComma": true,
     "disallowKeywordsOnNewLine": [
-        "else"
+      "else"
     ],
     "requireLineFeedAtFileEnd": true,
     "requireCapitalizedConstructors": true,
@@ -123,7 +127,7 @@
     "requireCapitalizedComments": false,
     "requireSpaceAfterLineComment": true,
     "requireSpacesInFunction": {
-        "beforeOpeningCurlyBrace": true
+      "beforeOpeningCurlyBrace": true
     },
     "validateLineBreaks": "LF",
     "validateQuoteMarks": "'"


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.